### PR TITLE
Add caching of checks for method existence

### DIFF
--- a/src/Charcoal/Config/AbstractConfig.php
+++ b/src/Charcoal/Config/AbstractConfig.php
@@ -152,20 +152,20 @@ abstract class AbstractConfig extends AbstractEntity implements
         }
 
         $getter = 'get'.ucfirst($key);
-        if (!isset($this->accessorsCache[$getter])) {
-            $this->accessorsCache[$getter] = is_callable([ $this, $getter ]);
+        if (!isset($this->mutatorCache[$getter])) {
+            $this->mutatorCache[$getter] = is_callable([ $this, $getter ]);
         }
 
-        if ($this->accessorsCache[$getter]) {
+        if ($this->mutatorCache[$getter]) {
             return ($this->{$getter}() !== null);
         }
 
         // -- START DEPRECATED
-        if (!isset($this->accessorsCache[$key])) {
-            $this->accessorsCache[$key] = is_callable([ $this, $key ]);
+        if (!isset($this->mutatorCache[$key])) {
+            $this->mutatorCache[$key] = is_callable([ $this, $key ]);
         }
 
-        if ($this->accessorsCache[$key]) {
+        if ($this->mutatorCache[$key]) {
             return ($this->{$key}() !== null);
         }
         // -- END DEPRECATED
@@ -213,20 +213,20 @@ abstract class AbstractConfig extends AbstractEntity implements
         }
 
         $getter = 'get'.ucfirst($key);
-        if (!isset($this->accessorsCache[$getter])) {
-            $this->accessorsCache[$getter] = is_callable([ $this, $getter ]);
+        if (!isset($this->mutatorCache[$getter])) {
+            $this->mutatorCache[$getter] = is_callable([ $this, $getter ]);
         }
 
-        if ($this->accessorsCache[$getter]) {
+        if ($this->mutatorCache[$getter]) {
             return $this->{$getter}();
         }
 
         // -- START DEPRECATED
-        if (!isset($this->accessorsCache[$key])) {
-            $this->accessorsCache[$key] = is_callable([ $this, $key ]);
+        if (!isset($this->mutatorCache[$key])) {
+            $this->mutatorCache[$key] = is_callable([ $this, $key ]);
         }
 
-        if ($this->accessorsCache[$key]) {
+        if ($this->mutatorCache[$key]) {
             return $this->{$key}();
         }
         // -- END DEPRECATED
@@ -273,17 +273,17 @@ abstract class AbstractConfig extends AbstractEntity implements
         }
 
         $setter = 'set'.ucfirst($key);
-        if (!isset($this->accessorsCache[$setter])) {
-            $this->accessorsCache[$setter] = is_callable([ $this, $setter ]);
+        if (!isset($this->mutatorCache[$setter])) {
+            $this->mutatorCache[$setter] = is_callable([ $this, $setter ]);
         }
 
-        if ($this->accessorsCache[$setter]) {
+        if ($this->mutatorCache[$setter]) {
             $this->{$setter}($value);
         } else {
             $this->{$key} = $value;
         }
 
-        $this->keysCache[$key] = true;
+        $this->keyCache[$key] = true;
     }
 
     /**

--- a/src/Charcoal/Config/AbstractConfig.php
+++ b/src/Charcoal/Config/AbstractConfig.php
@@ -152,18 +152,29 @@ abstract class AbstractConfig extends AbstractEntity implements
         }
 
         $getter = 'get'.ucfirst($key);
-        if (is_callable([ $this, $getter])) {
-            $value = $this->{$getter}();
-        } elseif (is_callable([ $this, $key ])) {
-            $value = $this->{$key}();
-        } else {
-            if (!isset($this->{$key})) {
-                return $this->hasInDelegates($key);
-            }
-            $value = $this->{$key};
+        if (!isset($this->accessorsCache[$getter])) {
+            $this->accessorsCache[$getter] = is_callable([ $this, $getter ]);
         }
 
-        return ($value !== null);
+        if ($this->accessorsCache[$getter]) {
+            return ($this->{$getter}() !== null);
+        }
+
+        // -- START DEPRECATED
+        if (!isset($this->accessorsCache[$key])) {
+            $this->accessorsCache[$key] = is_callable([ $this, $key ]);
+        }
+
+        if ($this->accessorsCache[$key]) {
+            return ($this->{$key}() !== null);
+        }
+        // -- END DEPRECATED
+
+        if (isset($this->{$key})) {
+            return true;
+        }
+
+        return $this->hasInDelegates($key);
     }
 
     /**
@@ -202,17 +213,29 @@ abstract class AbstractConfig extends AbstractEntity implements
         }
 
         $getter = 'get'.ucfirst($key);
-        if (is_callable([ $this, $getter])) {
-            return $this->{$getter}();
-        } elseif (is_callable([ $this, $key ])) {
-            return $this->{$key}();
-        } else {
-            if (isset($this->{$key})) {
-                return $this->{$key};
-            } else {
-                return $this->getInDelegates($key);
-            }
+        if (!isset($this->accessorsCache[$getter])) {
+            $this->accessorsCache[$getter] = is_callable([ $this, $getter ]);
         }
+
+        if ($this->accessorsCache[$getter]) {
+            return $this->{$getter}();
+        }
+
+        // -- START DEPRECATED
+        if (!isset($this->accessorsCache[$key])) {
+            $this->accessorsCache[$key] = is_callable([ $this, $key ]);
+        }
+
+        if ($this->accessorsCache[$key]) {
+            return $this->{$key}();
+        }
+        // -- END DEPRECATED
+
+        if (isset($this->{$key})) {
+            return $this->{$key};
+        }
+
+        return $this->getInDelegates($key);
     }
 
     /**
@@ -250,13 +273,17 @@ abstract class AbstractConfig extends AbstractEntity implements
         }
 
         $setter = 'set'.ucfirst($key);
-        if (is_callable([ $this, $setter ])) {
+        if (!isset($this->accessorsCache[$setter])) {
+            $this->accessorsCache[$setter] = is_callable([ $this, $setter ]);
+        }
+
+        if ($this->accessorsCache[$setter]) {
             $this->{$setter}($value);
         } else {
             $this->{$key} = $value;
         }
 
-        $this->keys[$key] = true;
+        $this->keysCache[$key] = true;
     }
 
     /**

--- a/src/Charcoal/Config/AbstractEntity.php
+++ b/src/Charcoal/Config/AbstractEntity.php
@@ -24,14 +24,14 @@ abstract class AbstractEntity implements EntityInterface
      *
      * @var (boolean|null)[]
      */
-    protected $keysCache = [];
+    protected $keyCache = [];
 
     /**
      * Holds a list of getters/setters per class.
      *
      * @var string[]
      */
-    protected $accessorsCache = [];
+    protected $mutatorCache = [];
 
     /**
      * Gets the data keys on this entity.
@@ -40,7 +40,7 @@ abstract class AbstractEntity implements EntityInterface
      */
     public function keys()
     {
-        return array_keys($this->keysCache);
+        return array_keys($this->keyCache);
     }
 
     /**
@@ -159,20 +159,20 @@ abstract class AbstractEntity implements EntityInterface
         }
 
         $getter = 'get'.ucfirst($key);
-        if (!isset($this->accessorsCache[$getter])) {
-            $this->accessorsCache[$getter] = is_callable([ $this, $getter ]);
+        if (!isset($this->mutatorCache[$getter])) {
+            $this->mutatorCache[$getter] = is_callable([ $this, $getter ]);
         }
 
-        if ($this->accessorsCache[$getter]) {
+        if ($this->mutatorCache[$getter]) {
             return ($this->{$getter}() !== null);
         }
 
         // -- START DEPRECATED
-        if (!isset($this->accessorsCache[$key])) {
-            $this->accessorsCache[$key] = is_callable([ $this, $key ]);
+        if (!isset($this->mutatorCache[$key])) {
+            $this->mutatorCache[$key] = is_callable([ $this, $key ]);
         }
 
-        if ($this->accessorsCache[$key]) {
+        if ($this->mutatorCache[$key]) {
             return ($this->{$key}() !== null);
         }
         // -- END DEPRECATED
@@ -214,20 +214,20 @@ abstract class AbstractEntity implements EntityInterface
         }
 
         $getter = 'get'.ucfirst($key);
-        if (!isset($this->accessorsCache[$getter])) {
-            $this->accessorsCache[$getter] = is_callable([ $this, $getter ]);
+        if (!isset($this->mutatorCache[$getter])) {
+            $this->mutatorCache[$getter] = is_callable([ $this, $getter ]);
         }
 
-        if ($this->accessorsCache[$getter]) {
+        if ($this->mutatorCache[$getter]) {
             return $this->{$getter}();
         }
 
         // -- START DEPRECATED
-        if (!isset($this->accessorsCache[$key])) {
-            $this->accessorsCache[$key] = is_callable([ $this, $key ]);
+        if (!isset($this->mutatorCache[$key])) {
+            $this->mutatorCache[$key] = is_callable([ $this, $key ]);
         }
 
-        if ($this->accessorsCache[$key]) {
+        if ($this->mutatorCache[$key]) {
             return $this->{$key}();
         }
         // -- END DEPRECATED
@@ -270,17 +270,17 @@ abstract class AbstractEntity implements EntityInterface
         }
 
         $setter = 'set'.ucfirst($key);
-        if (!isset($this->accessorsCache[$setter])) {
-            $this->accessorsCache[$setter] = is_callable([ $this, $setter ]);
+        if (!isset($this->mutatorCache[$setter])) {
+            $this->mutatorCache[$setter] = is_callable([ $this, $setter ]);
         }
 
-        if ($this->accessorsCache[$setter]) {
+        if ($this->mutatorCache[$setter]) {
             $this->{$setter}($value);
         } else {
             $this->{$key} = $value;
         }
 
-        $this->keysCache[$key] = true;
+        $this->keyCache[$key] = true;
     }
 
     /**
@@ -312,7 +312,7 @@ abstract class AbstractEntity implements EntityInterface
         }
 
         $this[$key] = null;
-        unset($this->keysCache[$key]);
+        unset($this->keyCache[$key]);
     }
 
     /**

--- a/tests/Charcoal/Config/Entity/EntityTest.php
+++ b/tests/Charcoal/Config/Entity/EntityTest.php
@@ -257,7 +257,7 @@ class EntityTest extends AbstractEntityTestCase
         $obj->setData($mutation);
         $that = unserialize(serialize($obj));
         $this->assertInstanceOf(get_class($obj), $that);
-        $this->assertEquals($obj, $that);
+        $this->assertEquals($obj->data(), $that->data());
         $this->assertEquals('Charcoal', $that['name']);
     }
 }

--- a/tests/Charcoal/Config/Mock/TreeEntity.php
+++ b/tests/Charcoal/Config/Mock/TreeEntity.php
@@ -45,16 +45,30 @@ class TreeEntity extends Entity implements SeparatorAwareInterface
             return false;
         }
 
-        if (is_callable([ $this, $key ])) {
-            $value = $this->{$key}();
-        } else {
-            if (!isset($this->{$key})) {
-                return false;
-            }
-            $value = $this->{$key};
+        $getter = 'get'.ucfirst($key);
+        if (!isset($this->accessorsCache[$getter])) {
+            $this->accessorsCache[$getter] = is_callable([ $this, $getter ]);
         }
 
-        return ($value !== null);
+        if ($this->accessorsCache[$getter]) {
+            return ($this->{$getter}() !== null);
+        }
+
+        // -- START DEPRECATED
+        if (!isset($this->accessorsCache[$key])) {
+            $this->accessorsCache[$key] = is_callable([ $this, $key ]);
+        }
+
+        if ($this->accessorsCache[$key]) {
+            return ($this->{$key}() !== null);
+        }
+        // -- END DEPRECATED
+
+        if (isset($this->{$key})) {
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -83,15 +97,30 @@ class TreeEntity extends Entity implements SeparatorAwareInterface
             return null;
         }
 
-        if (is_callable([ $this, $key ])) {
-            return $this->{$key}();
-        } else {
-            if (isset($this->{$key})) {
-                return $this->{$key};
-            } else {
-                return null;
-            }
+        $getter = 'get'.ucfirst($key);
+        if (!isset($this->accessorsCache[$getter])) {
+            $this->accessorsCache[$getter] = is_callable([ $this, $getter ]);
         }
+
+        if ($this->accessorsCache[$getter]) {
+            return $this->{$getter}();
+        }
+
+        // -- START DEPRECATED
+        if (!isset($this->accessorsCache[$key])) {
+            $this->accessorsCache[$key] = is_callable([ $this, $key ]);
+        }
+
+        if ($this->accessorsCache[$key]) {
+            return $this->{$key}();
+        }
+        // -- END DEPRECATED
+
+        if (isset($this->{$key})) {
+            return $this->{$key};
+        }
+
+        return null;
     }
 
     /**
@@ -123,12 +152,16 @@ class TreeEntity extends Entity implements SeparatorAwareInterface
         }
 
         $setter = 'set'.ucfirst($key);
-        if (is_callable([ $this, $setter ])) {
+        if (!isset($this->accessorsCache[$setter])) {
+            $this->accessorsCache[$setter] = is_callable([ $this, $setter ]);
+        }
+
+        if ($this->accessorsCache[$setter]) {
             $this->{$setter}($value);
         } else {
             $this->{$key} = $value;
         }
 
-        $this->keys[$key] = true;
+        $this->keysCache[$key] = true;
     }
 }

--- a/tests/Charcoal/Config/Mock/TreeEntity.php
+++ b/tests/Charcoal/Config/Mock/TreeEntity.php
@@ -46,20 +46,20 @@ class TreeEntity extends Entity implements SeparatorAwareInterface
         }
 
         $getter = 'get'.ucfirst($key);
-        if (!isset($this->accessorsCache[$getter])) {
-            $this->accessorsCache[$getter] = is_callable([ $this, $getter ]);
+        if (!isset($this->mutatorCache[$getter])) {
+            $this->mutatorCache[$getter] = is_callable([ $this, $getter ]);
         }
 
-        if ($this->accessorsCache[$getter]) {
+        if ($this->mutatorCache[$getter]) {
             return ($this->{$getter}() !== null);
         }
 
         // -- START DEPRECATED
-        if (!isset($this->accessorsCache[$key])) {
-            $this->accessorsCache[$key] = is_callable([ $this, $key ]);
+        if (!isset($this->mutatorCache[$key])) {
+            $this->mutatorCache[$key] = is_callable([ $this, $key ]);
         }
 
-        if ($this->accessorsCache[$key]) {
+        if ($this->mutatorCache[$key]) {
             return ($this->{$key}() !== null);
         }
         // -- END DEPRECATED
@@ -98,20 +98,20 @@ class TreeEntity extends Entity implements SeparatorAwareInterface
         }
 
         $getter = 'get'.ucfirst($key);
-        if (!isset($this->accessorsCache[$getter])) {
-            $this->accessorsCache[$getter] = is_callable([ $this, $getter ]);
+        if (!isset($this->mutatorCache[$getter])) {
+            $this->mutatorCache[$getter] = is_callable([ $this, $getter ]);
         }
 
-        if ($this->accessorsCache[$getter]) {
+        if ($this->mutatorCache[$getter]) {
             return $this->{$getter}();
         }
 
         // -- START DEPRECATED
-        if (!isset($this->accessorsCache[$key])) {
-            $this->accessorsCache[$key] = is_callable([ $this, $key ]);
+        if (!isset($this->mutatorCache[$key])) {
+            $this->mutatorCache[$key] = is_callable([ $this, $key ]);
         }
 
-        if ($this->accessorsCache[$key]) {
+        if ($this->mutatorCache[$key]) {
             return $this->{$key}();
         }
         // -- END DEPRECATED
@@ -152,16 +152,16 @@ class TreeEntity extends Entity implements SeparatorAwareInterface
         }
 
         $setter = 'set'.ucfirst($key);
-        if (!isset($this->accessorsCache[$setter])) {
-            $this->accessorsCache[$setter] = is_callable([ $this, $setter ]);
+        if (!isset($this->mutatorCache[$setter])) {
+            $this->mutatorCache[$setter] = is_callable([ $this, $setter ]);
         }
 
-        if ($this->accessorsCache[$setter]) {
+        if ($this->mutatorCache[$setter]) {
             $this->{$setter}($value);
         } else {
             $this->{$key} = $value;
         }
 
-        $this->keysCache[$key] = true;
+        $this->keyCache[$key] = true;
     }
 }


### PR DESCRIPTION
Added:
- Property `AbstractEntity::$mutatorCache` to store dictionary of camelized strings
- Comments to highlight deprecated non-get-prefixed accessors

Changed:
- Renamed property `$keys` to `$keyCache` on `AbstractEntity`  
  (mitigate occurrences where `keys` is needed as a concrete property)
- Array access methods to cache `is_callable()` function checks
- Method `EntityTest::testSerializable()` to compare entity data instead of instances